### PR TITLE
Add "update conda" instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ This downloads all of the dependencies and then all you have to do is:
 conda activate fastai
 ```
 
+If you see errors (particularly on Windows, related to `pytorch` and `mkl`), you should first try updating `conda` itself before opening an issue here:
+
+```sh
+conda update conda
+conda update anaconda
+```
+
 To update everything at any time, cd to your repo and:
 
 ```sh


### PR DESCRIPTION
Install can fail on windows if `conda` is not up to date with `pytorch`/`mkl` compatibility errors. Updating conda/anaconda solves the issue, but that's not obvious from the error message.